### PR TITLE
Fix roof position counter drift: motion gate + filters + limit-switch re-sync

### DIFF
--- a/MonetRoof/MONETroof/POUs/FB_Roof.TcPOU
+++ b/MonetRoof/MONETroof/POUs/FB_Roof.TcPOU
@@ -57,6 +57,9 @@ VAR
 	// opening or closing?
 	is_opening				: BOOL;		// move direction
 	is_closing				: BOOL;	
+	
+	// boot-time snap guard
+	bRoofInitialized		: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -111,6 +114,35 @@ END_IF
 // stop on limit switches
 IF (is_closing AND roof_limit_closed) OR (is_opening AND roof_limit_open) THEN
 	Stop();
+END_IF
+
+// boot-time position snap: warm restart with the roof parked at a limit.
+// One-shot on the first cycle, both sensors together (symmetric — no |diff|).
+IF NOT bRoofInitialized THEN
+	bRoofInitialized := TRUE;
+	IF roof_limit_closed THEN
+		motors[1].position := motors[1].min_position;
+		motors[2].position := motors[2].min_position;
+	ELSIF roof_limit_open THEN
+		motors[1].position := motors[1].max_position;
+		motors[2].position := motors[2].max_position;
+	END_IF
+END_IF
+
+// limit re-sync: snap both drives to the physical end position (both sensors
+// engaged). Direction-gated: must NOT fire at the START of a move while the
+// opposite limit switch is still engaged (the first counter edge can arrive
+// ~0.5 s before the closed switch releases) — an ungated snap would erase
+// those legitimate counts and leave the move one count short. While stalled
+// against a limit the snap holds the position, so stall-jitter counts cannot
+// drive it past the end position.
+IF is_closing AND roof_limit_closed THEN
+	motors[1].position := motors[1].min_position;
+	motors[2].position := motors[2].min_position;
+END_IF
+IF is_opening AND roof_limit_open THEN
+	motors[1].position := motors[1].max_position;
+	motors[2].position := motors[2].max_position;
 END_IF
 
 // call motors

--- a/MonetRoof/MONETroof/POUs/FB_RoofMotor.TcPOU
+++ b/MonetRoof/MONETroof/POUs/FB_RoofMotor.TcPOU
@@ -10,6 +10,10 @@ VAR_INPUT
 	real_speed				: INT;		// signed speed
 	zero_counter			: BOOL := FALSE;	// reset position counter to zero
 	comm					: I_Comm;
+	
+	// counting filters (insurance; defaults sized from the recordings — plan 2026-08-20)
+	counter_debounce		: TIME := T#10MS;	// min. on-time of a sensor pulse — keep < narrowest legit pulse (20 ms)
+	counter_min_spacing		: TIME := T#50MS;	// min. time between accepted counts — keep < rotation period (600 ms)
 END_VAR
 VAR_OUTPUT PERSISTENT
 	position				: INT;	// position
@@ -19,6 +23,9 @@ VAR_OUTPUT
 	
 	// moving
 	moving					: BOOL;
+	
+	// debug: raw (unfiltered, ungated) edge count for validation
+	raw_counts				: DINT;
 	
 	// error 
 	motor_error		AT%I*	: BOOL;
@@ -33,16 +40,15 @@ VAR_OUTPUT
 	position_close			: INT := -1000;
 END_VAR
 VAR
-	// triggers for opened/closed
-	opened_trigger			: R_TRIG;
-	closed_trigger			: R_TRIG;
-	
 	// error
 	drive_error_event		: FB_EventLog;
 
 	// inductive sensor for counting rotation
 	counter			AT%I*	: BOOL;
 	counter_trig			: R_TRIG;
+	counter_raw_trig		: R_TRIG;	// raw (unfiltered) edge trigger — for validation only
+	tonDebounce				: TON;		// level debounce for the sensor pulse
+	tonSpacing				: TON;		// rate limit: min. spacing between accepted counts
 	
 	// reset command to drive
 	reset_command			: BOOL;
@@ -84,20 +90,39 @@ percent_open := 1.0 * (position - min_position) / (max_position - min_position) 
 // get direction
 direction_open := real_speed > 0;
 direction_close := real_speed < 0;
-	
-// counter for position
-counter_trig(CLK := counter);
-IF counter_trig.Q THEN
-	IF direction_open THEN
-		position := position + 1;
-	ELSE
-		position := position - 1;
+
+// set moving before the counter gate (motion gate: no counting while idle)
+moving := real_speed <> 0;
+
+// counter for position — filtered and gated.
+// The limit re-sync in FB_Roof is the primary protection; these layers are
+// insurance only. Deliberately NOT gated on the limit switches: that would
+// blind the sync check to a broken connection or a stalled drive.
+tonDebounce(IN := counter, PT := counter_debounce);	// stable-high filter (kills short glitches)
+counter_trig(CLK := tonDebounce.Q);					// edge of the filtered signal
+
+// raw edge count (unfiltered, ungated) — for validation/comparison
+counter_raw_trig(CLK := counter);
+IF counter_raw_trig.Q THEN
+	raw_counts := raw_counts + 1;
+END_IF
+
+IF counter_trig.Q AND moving THEN					// motion gate
+	IF tonSpacing.Q THEN							// spacing window since last accepted count elapsed -> accept
+		tonSpacing(IN := FALSE);					// restart the spacing window
+		IF direction_open THEN
+			position := position + 1;
+		ELSIF direction_close THEN
+			position := position - 1;
+		END_IF
 	END_IF
 END_IF
+tonSpacing(IN := TRUE, PT := counter_min_spacing);	// rate limit timer (runs continuously)
 
 // zero?
 IF zero_counter THEN
 	position := 0;
+	raw_counts := 0;
 END_IF
 
 // remember position when entering/leaving limit switches
@@ -118,23 +143,8 @@ IF position_close_off_trig.Q THEN
 	position_close := -1000;
 END_IF
 
-// if in limits, reset position, but only if moving in that direction
-(*
-closed_trigger(CLK := closed);
-IF direction_close AND closed_trigger.Q THEN
-	position := min_position;
-END_IF
-opened_trigger(CLK := opened);
-IF direction_open AND opened_trigger.Q THEN
-	position := max_position;
-END_IF
-*)
-
 // absolute speed
 speed := ABS(real_speed);
-
-// set moving to zero, if no movement
-moving := real_speed <> 0;
 
 // error
 drive_error_event(	

--- a/specs/plans/2026-08-20-position-counter-fix-plan.md
+++ b/specs/plans/2026-08-20-position-counter-fix-plan.md
@@ -1,6 +1,7 @@
 # Plan: Fix the roof position counter (pulse rattling / over-counting)
 
-Status: draft — measurement first, then implement the filter. First live
+Status: **implemented (steps 3–4)** on branch `fix/roof-counter-resync` —
+measurement first, then the filter. First live
 recording (`Roof.svdx`, Becky) decoded 2026-08-20 — measured values in §3;
 decoding format documented in
 `BROTLib/specs/design/twincat-scopeview-svdx-format.md`.
@@ -620,18 +621,23 @@ positions. This is the fix for the measured failure (§3.3).
       useful only as a one-off pulse-width diagnostic, not part of the fix.
 - [ ] **Step 2 — Decide**: decided — no over-counting; the fix is the re-sync
       + gates (§4, §5).
-- [ ] **Step 3 — Gates + filters (insurance)**: implement the motion gate
+- [x] **Step 3 — Gates + filters (insurance)**: implement the motion gate
       and the debounce/spacing layers in `FB_RoofMotor.TcPOU` with `VAR_INPUT`
       tuning parameters; keep the raw counter path available for comparison
       (e.g. a debug output `raw_counts`). Do **not** gate counting on the
       limit switches — that would blind the sync check to a broken
-      connection or stalled drive (§5).
-- [ ] **Step 4 — Re-sync (highest value)**: implement the symmetric limit
+      connection or stalled drive (§5). *(Implemented 2026-08-20:
+      `counter_debounce`/`counter_min_spacing` inputs, `tonDebounce` +
+      `tonSpacing` + motion gate, `raw_counts` debug output, `zero_counter`
+      also resets `raw_counts`.)*
+- [x] **Step 4 — Re-sync (highest value)**: implement the symmetric limit
       snap in `FB_Roof` (both motors snap to `min_position`/`max_position`
       when *both* closed / opened switches engage, §5 safety net) — clears any
       residue at every full open and close, and (given the mechanical
       connection) guarantees the two counters of a half agree after every full
-      cycle.
+      cycle. *(Implemented 2026-08-20: direction-gated re-sync after the
+      stop-on-limit block + one-shot boot-time snap, both at `FB_Roof` level
+      using `roof_limit_*`.)*
 - [ ] **Step 5 — Validate**: on the live system, do N open/stop/close cycles
       (the test that reproduces the failure); verify `position` at the limits
       equals `min_position`/`max_position` exactly, that the two counters of
@@ -643,6 +649,32 @@ positions. This is the fix for the measured failure (§3.3).
 - [ ] **Step 6 — Cleanup**: remove or disable the measurement task once the
       filter is validated; document the tuned values in the README
       (`Configuration` table) and in the code comments.
+
+### Implementation notes (2026-08-20, branch `fix/roof-counter-resync`)
+
+Two deliberate deviations from the §5 code draft (the *prose* design intent
+was followed where the draft code contradicted it):
+
+1. **Rate-limit condition corrected.** The draft counter block uses
+   `IF NOT tonSpacing.Q THEN … count … ELSE tonSpacing(IN := FALSE)` — with
+   standard `TON` semantics (`Q` = *elapsed*, not *running*) this accepts every
+   edge inside the spacing window and rejects the first edge *after* it: the
+   opposite of the described "ignore an edge within minimum spacing after the
+   last accepted count". Implemented instead: accept only when `tonSpacing.Q`
+   (window elapsed) and restart the window on each accepted count
+   (`tonSpacing(IN := FALSE)` then re-`IN := TRUE` next cycle).
+2. **Boot-time snap moved to `FB_Roof` (both-sensors condition).** The draft
+   places it in `FB_RoofMotor` per-motor (`IF closed THEN position :=
+   min_position`); a per-motor boot snap can create an immediate `|diff| = 1`
+   if only one switch is engaged at startup — the exact transient the
+   symmetric design avoids. Implemented as a one-shot in `FB_Roof` on the
+   first cycle using `roof_limit_closed` / `roof_limit_open` (both sensors
+   together), so it snaps both motors or neither. `FB_RoofMotor` therefore
+   does **not** get `bPositionInitialized` (the plan's `FB_Roof`-level
+   direction-gated re-sync itself is unchanged from §5).
+
+Also: `raw_counts` is reset together with `position` by `zero_counter`, so the
+raw-vs-filtered comparison stays valid after a manual zero.
 
 ## 7. Files to touch
 


### PR DESCRIPTION
## What

Implements plan §6 steps 3–4 of `specs/plans/2026-08-20-position-counter-fix-plan.md` (see that doc for the full investigation: 4 recordings decoded, no over-counting, clean 0.6 s pulses, `sync_error` is an un-cleared ±1 phase residue crossing the `max_position_diff = 2` threshold).

**Root cause:** the limit-switch position snap in `FB_RoofMotor` is commented out, so the ±1 counter difference (phase-offset blocks on mechanically connected drives) survives every full open/close; during a move the phase oscillation pushes `|diff|` to 2 and trips `sync_error`.

## Changes

**`FB_RoofMotor.TcPOU`** — counting filters (insurance; the re-sync is the primary fix):
- New tunable inputs `counter_debounce` (10 ms) / `counter_min_spacing` (50 ms), defaults sized from the measured 20 ms narrowest pulse / 600 ms rotation period.
- Motion gate: `moving := real_speed <> 0` moved before the counter block — no counting while idle (wind-rattle protection). Deliberately **not** gated on the limit switches: that would blind the sync check to a broken connection / stalled drive.
- Level debounce (`tonDebounce`) + rate limit (`tonSpacing`) as insurance.
- `raw_counts` debug output (unfiltered, ungated) for validation; reset together with `position` by `zero_counter`.
- Removed the commented-out per-motor snap and its now-unused `opened_trigger`/`closed_trigger` (superseded by the `FB_Roof`-level re-sync).

**`FB_Roof.TcPOU`** — the re-sync (highest value):
- Symmetric limit snap: when **both** closed / opened switches engage (`roof_limit_closed`/`roof_limit_open`), both motors snap to `min_position`/`max_position`. Direction-gated (`is_closing`/`is_opening`) so it cannot erase the legitimate first-rotation counts at the start of a move while the opposite limit switch is still engaged (~0.5 s overlap, measured).
- One-shot boot-time snap (warm restart parked at a limit), both-sensors condition.

**Plan** — steps 3–4 marked done + implementation notes.

## Deliberate deviations from the §5 code draft (documented in the plan)

1. **Rate-limit condition corrected**: the draft's `IF NOT tonSpacing.Q THEN count` accepts every edge *inside* the spacing window with standard TON semantics (`Q` = elapsed). Implemented per the prose intent: accept only when the spacing window has elapsed, restart on each accepted count.
2. **Boot snap moved to `FB_Roof` (both-sensors)**: the draft's per-motor boot snap (`IF closed THEN position := min_position`) can create an immediate `|diff| = 1` if only one switch is engaged at startup; the roof-level version snaps both motors or neither.

## Validation needed (plan §6 step 5 — not done yet, requires the live system)

N open/stop/close cycles: positions exactly `min_position`/`max_position` at the limits, counters of each half agree after every full cycle, no spurious `sync_error`/`limit_error`, no legitimate counts lost (`raw_counts` vs `position` over a full cycle). Also still open: verify opened-limit repeatability (no recording ever reached full open).