### PR TITLE
Fix compile error: snap position via FB_RoofMotor.SetPosition method

### DIFF
--- a/MonetRoof/MONETroof/POUs/FB_Roof.TcPOU
+++ b/MonetRoof/MONETroof/POUs/FB_Roof.TcPOU
@@ -121,11 +121,11 @@ END_IF
 IF NOT bRoofInitialized THEN
 	bRoofInitialized := TRUE;
 	IF roof_limit_closed THEN
-		motors[1].position := motors[1].min_position;
-		motors[2].position := motors[2].min_position;
+		motors[1].SetPosition(motors[1].min_position);
+		motors[2].SetPosition(motors[2].min_position);
 	ELSIF roof_limit_open THEN
-		motors[1].position := motors[1].max_position;
-		motors[2].position := motors[2].max_position;
+		motors[1].SetPosition(motors[1].max_position);
+		motors[2].SetPosition(motors[2].max_position);
 	END_IF
 END_IF
 
@@ -137,12 +137,12 @@ END_IF
 // against a limit the snap holds the position, so stall-jitter counts cannot
 // drive it past the end position.
 IF is_closing AND roof_limit_closed THEN
-	motors[1].position := motors[1].min_position;
-	motors[2].position := motors[2].min_position;
+	motors[1].SetPosition(motors[1].min_position);
+	motors[2].SetPosition(motors[2].min_position);
 END_IF
 IF is_opening AND roof_limit_open THEN
-	motors[1].position := motors[1].max_position;
-	motors[2].position := motors[2].max_position;
+	motors[1].SetPosition(motors[1].max_position);
+	motors[2].SetPosition(motors[2].max_position);
 END_IF
 
 // call motors

--- a/MonetRoof/MONETroof/POUs/FB_RoofMotor.TcPOU
+++ b/MonetRoof/MONETroof/POUs/FB_RoofMotor.TcPOU
@@ -194,6 +194,18 @@ END_VAR
         <ST><![CDATA[reset_command := TRUE;]]></ST>
       </Implementation>
     </Method>
+    <Method Name="SetPosition" Id="{D579E16E-908F-46C7-A5F1-23B0FAF96397}">
+      <Declaration><![CDATA[METHOD SetPosition : BOOL
+VAR_INPUT
+	position_value		: INT;		// new position value (e.g. min/max_position on limit re-sync)
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[// 'position' is a VAR_OUTPUT — read-only from outside the FB, so the
+// FB_Roof-level limit re-sync sets it through this method.
+position := position_value;]]></ST>
+      </Implementation>
+    </Method>
     <LineIds Name="FB_RoofMotor">
       <LineId Id="544" Count="0" />
       <LineId Id="546" Count="0" />

--- a/specs/plans/2026-08-20-position-counter-fix-plan.md
+++ b/specs/plans/2026-08-20-position-counter-fix-plan.md
@@ -508,14 +508,18 @@ switches" block; no declaration changes needed — uses existing
 // limit switch is still engaged (measured: first counter edge ~0.5 s before
 // the closed switch releases) — see caveats below.
 IF is_closing AND roof_limit_closed THEN
-    motors[1].position := motors[1].min_position;
-    motors[2].position := motors[2].min_position;
+    motors[1].SetPosition(motors[1].min_position);
+    motors[2].SetPosition(motors[2].min_position);
 END_IF
 IF is_opening AND roof_limit_open THEN
-    motors[1].position := motors[1].max_position;
-    motors[2].position := motors[2].max_position;
+    motors[1].SetPosition(motors[1].max_position);
+    motors[2].SetPosition(motors[2].max_position);
 END_IF
 ```
+
+(`position` is a `VAR_OUTPUT` of `FB_RoofMotor` — read-only from outside the
+FB — so the snap goes through the new `SetPosition` method; see the
+implementation notes.)
 
 Placement notes:
 
@@ -675,6 +679,17 @@ was followed where the draft code contradicted it):
 
 Also: `raw_counts` is reset together with `position` by `zero_counter`, so the
 raw-vs-filtered comparison stays valid after a manual zero.
+
+### Compile fix (2026-08-21, branch `fix/roofmotor-position-write`)
+
+The merged code did **not** compile: `motors[1].position := …` in `FB_Roof`
+failed with *"'position' is no input of 'FB_RoofMotor'"* — `position` is a
+`VAR_OUTPUT` (PERSISTENT) and is read-only from outside the FB; only inputs
+can be assigned at the call site. Fix: new `SetPosition(position_value : INT)`
+method on `FB_RoofMotor` (methods may write the FB's own outputs), and the
+eight snap assignments in `FB_Roof` now call
+`motors[1].SetPosition(motors[1].min_position)` etc. §5 snippet updated to the
+compilable form.
 
 ## 7. Files to touch
 


### PR DESCRIPTION
## Problem

The merged position-counter fix does not compile (TwinCAT):

```
Error  'position' is no input of 'FB_RoofMotor'   FB_Roof.TcPOU (8×)
```

`position` is a `VAR_OUTPUT PERSISTENT` of `FB_RoofMotor` — read-only from outside the FB. The `FB_Roof`-level limit re-sync and boot-time snap wrote `motors[i].position := …` directly, which TwinCAT rejects (only inputs are assignable at the call site).

## Fix

- **`FB_RoofMotor.TcPOU`**: new `SetPosition(position_value : INT)` method (methods may write the FB's own outputs).
- **`FB_Roof.TcPOU`**: all eight snap assignments (boot snap ×4, limit re-sync ×4) now call `motors[1].SetPosition(motors[1].min_position)` / `…max_position` / `motors[2]…` instead of writing the output directly.
- **Plan**: §5 `FB_Roof` snippet updated to the compilable form + compile-fix note in the implementation notes.

No logic change — same snap values, same placement, same direction gating. Verified: no `.<output> :=` writes to motor members remain outside `FB_RoofMotor`, both POUs are well-formed XML.

After merge: `v1.1.0` on `main` still contains the broken code — a patch bump (`v1.1.1`) + `main` merge will be needed.